### PR TITLE
Update the opponent also be NUguses

### DIFF
--- a/controllers/referee/game.json
+++ b/controllers/referee/game.json
@@ -25,8 +25,8 @@
     ]
   },
   "blue": {
-    "id": 25,
-    "config": "team_2.json",
+    "id": 13,
+    "config": "teams/nubots.json",
     "hosts": [
       "127.0.0.1",
       "192.168.123.41",


### PR DESCRIPTION
I think this would be a good change to put into the fork. I've had it locally since testing some team behaviour and seems to make sense. Rather than generating Darwins for the second team, we generate NUguses that we can run. 